### PR TITLE
Loadout item point cost reductions

### DIFF
--- a/code/modules/client/preference_setup/loadout/lists/eyegear.dm
+++ b/code/modules/client/preference_setup/loadout/lists/eyegear.dm
@@ -84,17 +84,17 @@
 /datum/gear/eyes/shades/
 	display_name = "sunglasses"
 	path = /obj/item/clothing/glasses/sunglasses
-	cost = 3
+	cost = 2
 
 /datum/gear/eyes/shades/sunglasses
 	display_name = "sunglasses, fat"
 	path = /obj/item/clothing/glasses/sunglasses/big
-	cost = 3
+	cost = 2
 
 /datum/gear/eyes/shades/prescriptionsun
 	display_name = "sunglasses, presciption"
 	path = /obj/item/clothing/glasses/sunglasses/prescription
-	cost = 3
+	cost = 2
 
 /datum/gear/eyes/hudpatch
 	display_name = "iPatch"

--- a/code/modules/client/preference_setup/loadout/lists/gloves.dm
+++ b/code/modules/client/preference_setup/loadout/lists/gloves.dm
@@ -8,6 +8,7 @@
 	display_name = "gloves, colored"
 	flags = GEAR_HAS_COLOR_SELECTION
 	path = /obj/item/clothing/gloves/color
+	cost = 1
 
 /datum/gear/gloves/latex
 	display_name = "gloves, latex"

--- a/code/modules/client/preference_setup/loadout/lists/storage.dm
+++ b/code/modules/client/preference_setup/loadout/lists/storage.dm
@@ -16,7 +16,7 @@
 /datum/gear/storage/bandolier
 	display_name = "bandolier"
 	path = /obj/item/clothing/accessory/storage/bandolier
-	cost = 3
+	cost = 2
 
 /datum/gear/storage/waistpack
 	display_name = "waist pack"

--- a/code/modules/client/preference_setup/loadout/lists/suits.dm
+++ b/code/modules/client/preference_setup/loadout/lists/suits.dm
@@ -115,7 +115,7 @@
 /datum/gear/suit/trenchcoat
 	display_name = "trenchcoat selection"
 	path = /obj/item/clothing/suit
-	cost = 3
+	cost = 2
 
 /datum/gear/suit/trenchcoat/get_gear_tweak_options()
 	. = ..()
@@ -136,4 +136,4 @@
 	display_name = "plain cloak"
 	path = /obj/item/clothing/accessory/cloak
 	flags = GEAR_HAS_COLOR_SELECTION
-	cost = 3
+	cost = 2

--- a/code/modules/client/preference_setup/loadout/lists/utility.dm
+++ b/code/modules/client/preference_setup/loadout/lists/utility.dm
@@ -64,7 +64,7 @@
 /datum/gear/utility/hand_labeler
 	display_name = "hand labeler"
 	path = /obj/item/hand_labeler
-	cost = 3
+	cost = 2
 
 /****************
 modular computers
@@ -73,17 +73,17 @@ modular computers
 /datum/gear/utility/cheaptablet
 	display_name = "tablet computer, cheap"
 	path = /obj/item/modular_computer/tablet/preset/custom_loadout/cheap
-	cost = 3
+	cost = 2
 
 /datum/gear/utility/normaltablet
 	display_name = "tablet computer, advanced"
 	path = /obj/item/modular_computer/tablet/preset/custom_loadout/advanced
-	cost = 4
+	cost = 3
 
 /datum/gear/utility/customtablet
 	display_name = "tablet computer, custom"
 	path = /obj/item/modular_computer/tablet
-	cost = 4
+	cost = 3
 
 /datum/gear/utility/customtablet/get_gear_tweak_options()
 	. = ..() | /datum/gear_tweak/tablet
@@ -91,9 +91,9 @@ modular computers
 /datum/gear/utility/cheaplaptop
 	display_name = "laptop computer, cheap"
 	path = /obj/item/modular_computer/laptop/preset/custom_loadout/cheap
-	cost = 5
+	cost = 4
 
 /datum/gear/utility/normallaptop
 	display_name = "laptop computer, advanced"
 	path = /obj/item/modular_computer/laptop/preset/custom_loadout/advanced
-	cost = 6
+	cost = 5


### PR DESCRIPTION
Adjusts the loadout point cost of the following items:
- Coloured gloves, 2 -> 1.
- Bandolier, 3 -> 2.
- Trenchcoat selection, 3 -> 2.
- Plain cloak, 3 -> 2.
- Cheap tablet, 3 -> 2.
- Advanced/custom tablet, 4 -> 3.
- Cheap laptop, 5 -> 4.
- Advanced laptop, 6 -> 5.
- Hand labeler, 3 -> 2.
- All sunglasses, 3 -> 2.

This should hopefully allow people to take more of what they want, while still being restrictive in choices for more 'useful' or 'functional' items.