### PR TITLE
Loadout item point cost reductions part II

### DIFF
--- a/code/modules/client/preference_setup/loadout/lists/accessories.dm
+++ b/code/modules/client/preference_setup/loadout/lists/accessories.dm
@@ -57,18 +57,22 @@
 /datum/gear/accessory/armband_security
 	display_name = "security armband"
 	path = /obj/item/clothing/accessory/armband
+	cost = 0
 
 /datum/gear/accessory/armband_cargo
 	display_name = "cargo armband"
 	path = /obj/item/clothing/accessory/armband/cargo
+	cost = 0
 
 /datum/gear/accessory/armband_medical
 	display_name = "medical armband"
 	path = /obj/item/clothing/accessory/armband/med
+	cost = 0
 
 /datum/gear/accessory/armband_engineering
 	display_name = "engineering armband"
 	path = /obj/item/clothing/accessory/armband/engine
+	cost = 0
 
 /datum/gear/accessory/ftupin
 	display_name = "Free Trade Union pin"

--- a/code/modules/client/preference_setup/loadout/lists/eyegear.dm
+++ b/code/modules/client/preference_setup/loadout/lists/eyegear.dm
@@ -84,17 +84,17 @@
 /datum/gear/eyes/shades/
 	display_name = "sunglasses"
 	path = /obj/item/clothing/glasses/sunglasses
-	cost = 3
+	cost = 2
 
 /datum/gear/eyes/shades/sunglasses
 	display_name = "sunglasses, fat"
 	path = /obj/item/clothing/glasses/sunglasses/big
-	cost = 3
+	cost = 2
 
 /datum/gear/eyes/shades/prescriptionsun
 	display_name = "sunglasses, presciption"
 	path = /obj/item/clothing/glasses/sunglasses/prescription
-	cost = 3
+	cost = 2
 
 /datum/gear/eyes/hudpatch
 	display_name = "iPatch"

--- a/code/modules/client/preference_setup/loadout/lists/gloves.dm
+++ b/code/modules/client/preference_setup/loadout/lists/gloves.dm
@@ -8,6 +8,7 @@
 	display_name = "gloves, colored"
 	flags = GEAR_HAS_COLOR_SELECTION
 	path = /obj/item/clothing/gloves/color
+	cost = 1
 
 /datum/gear/gloves/latex
 	display_name = "gloves, latex"

--- a/code/modules/client/preference_setup/loadout/lists/misc.dm
+++ b/code/modules/client/preference_setup/loadout/lists/misc.dm
@@ -5,6 +5,7 @@
 /datum/gear/union_card
 	display_name = "union membership"
 	path = /obj/item/card/union
+	cost = 0
 
 /datum/gear/union_card/spawn_on_mob(var/mob/living/carbon/human/H, var/metadata)
 	. = ..()
@@ -124,6 +125,7 @@
 	display_name = "passport"
 	path = /obj/item/passport
 	custom_setup_proc = /obj/item/passport/proc/set_info
+	cost = 0
 
 /datum/gear/mirror
 	display_name = "handheld mirror"

--- a/code/modules/client/preference_setup/loadout/lists/storage.dm
+++ b/code/modules/client/preference_setup/loadout/lists/storage.dm
@@ -16,7 +16,7 @@
 /datum/gear/storage/bandolier
 	display_name = "bandolier"
 	path = /obj/item/clothing/accessory/storage/bandolier
-	cost = 3
+	cost = 2
 
 /datum/gear/storage/waistpack
 	display_name = "waist pack"

--- a/code/modules/client/preference_setup/loadout/lists/storage.dm
+++ b/code/modules/client/preference_setup/loadout/lists/storage.dm
@@ -28,7 +28,7 @@
 /datum/gear/storage/waistpack/big
 	display_name = "large waist pack"
 	path = /obj/item/storage/belt/waistpack/big
-	cost = 4
+	cost = 3
 
 /datum/gear/accessory/wallet
 	display_name = "wallet, colour select"

--- a/code/modules/client/preference_setup/loadout/lists/suits.dm
+++ b/code/modules/client/preference_setup/loadout/lists/suits.dm
@@ -115,7 +115,7 @@
 /datum/gear/suit/trenchcoat
 	display_name = "trenchcoat selection"
 	path = /obj/item/clothing/suit
-	cost = 3
+	cost = 2
 
 /datum/gear/suit/trenchcoat/get_gear_tweak_options()
 	. = ..()
@@ -136,4 +136,4 @@
 	display_name = "plain cloak"
 	path = /obj/item/clothing/accessory/cloak
 	flags = GEAR_HAS_COLOR_SELECTION
-	cost = 3
+	cost = 2

--- a/code/modules/client/preference_setup/loadout/lists/utility.dm
+++ b/code/modules/client/preference_setup/loadout/lists/utility.dm
@@ -64,7 +64,7 @@
 /datum/gear/utility/hand_labeler
 	display_name = "hand labeler"
 	path = /obj/item/hand_labeler
-	cost = 3
+	cost = 2
 
 /****************
 modular computers
@@ -73,17 +73,17 @@ modular computers
 /datum/gear/utility/cheaptablet
 	display_name = "tablet computer, cheap"
 	path = /obj/item/modular_computer/tablet/preset/custom_loadout/cheap
-	cost = 3
+	cost = 2
 
 /datum/gear/utility/normaltablet
 	display_name = "tablet computer, advanced"
 	path = /obj/item/modular_computer/tablet/preset/custom_loadout/advanced
-	cost = 4
+	cost = 3
 
 /datum/gear/utility/customtablet
 	display_name = "tablet computer, custom"
 	path = /obj/item/modular_computer/tablet
-	cost = 4
+	cost = 3
 
 /datum/gear/utility/customtablet/get_gear_tweak_options()
 	. = ..() | /datum/gear_tweak/tablet
@@ -91,9 +91,9 @@ modular computers
 /datum/gear/utility/cheaplaptop
 	display_name = "laptop computer, cheap"
 	path = /obj/item/modular_computer/laptop/preset/custom_loadout/cheap
-	cost = 5
+	cost = 4
 
 /datum/gear/utility/normallaptop
 	display_name = "laptop computer, advanced"
 	path = /obj/item/modular_computer/laptop/preset/custom_loadout/advanced
-	cost = 6
+	cost = 5

--- a/code/modules/client/preference_setup/loadout/lists/utility.dm
+++ b/code/modules/client/preference_setup/loadout/lists/utility.dm
@@ -49,7 +49,7 @@
 /datum/gear/accessory/stethoscope
 	display_name = "stethoscope (medical)"
 	path = /obj/item/clothing/accessory/stethoscope
-	cost = 2
+	cost = 1
 
 /datum/gear/utility/pen
 	display_name = "Multicolored Pen"


### PR DESCRIPTION
Adjusts the loadout point cost of the following items:
- Departmental armbands, 1 -> 0.
- Union membership card, 1 -> 0.
- Passport, 1 -> 0.
- Large waist pack, 4 -> 3.
- Stethoscope, 2 -> 1.

Round two of the changes aimed at making things more accessible. Flavour items which everybody would realistically be carrying have been lowered to zero, along with departmental-locked items being more accessible with the caveat of their department-locked status.